### PR TITLE
Remove notebooks from language summary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
## What does this do?

Our git summary shows notebooks are the main code here, which is not ideal and only does this as the notebook files are large. I want this to show as a Python project cos it is.